### PR TITLE
FIX: aws region passed to image scanner

### DIFF
--- a/App.go
+++ b/App.go
@@ -434,6 +434,7 @@ func run(ciCdRequest *CiCdTriggerEvent) (artifactUploaded bool, err error) {
 		scanEvent := &ScanEvent{Image: dest, ImageDigest: digest, PipelineId: ciCdRequest.CiRequest.PipelineId, UserId: ciCdRequest.CiRequest.TriggeredBy}
 		scanEvent.AccessKey = ciCdRequest.CiRequest.AccessKey
 		scanEvent.SecretKey = ciCdRequest.CiRequest.SecretKey
+		scanEvent.AwsRegion = ciCdRequest.CiRequest.AwsRegion
 		err = SendEventToClairUtility(scanEvent)
 		if err != nil {
 			log.Println(err)

--- a/EventUtil.go
+++ b/EventUtil.go
@@ -217,8 +217,8 @@ func SendEventToClairUtility(event *ScanEvent) error {
 		log.Println(devtron, "err in image scanner app over rest", err)
 		return err
 	}
-	log.Println(devtron,resp.StatusCode())
-	log.Println(devtron,resp)
+	log.Println(devtron, resp.StatusCode())
+	log.Println(devtron, resp)
 	return nil
 }
 
@@ -233,4 +233,5 @@ type ScanEvent struct {
 	AccessKey    string `json:"accessKey"`
 	SecretKey    string `json:"secretKey"`
 	Token        string `json:"token"`
+	AwsRegion    string `json:"awsRegion"`
 }


### PR DESCRIPTION
# Description

aws region fixed as of now in image scanning service, passed it from devtron and ci runner to image scanner. took it from database.

Fixes # (issue) : https://github.com/devtron-labs/devtron/issues/650

Linked # (PR) : https://github.com/devtron-labs/devtron/pull/657,  https://github.com/devtron-labs/image-scanner/pull/1

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [x] Aws region passed in event payload success.

# Checklist:

* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have performed a self-review of my own code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] I have tested it for all user roles


