### PR TITLE
FIX - updated payload for image scanning

### DIFF
--- a/App.go
+++ b/App.go
@@ -77,7 +77,7 @@ type CiArtifactDTO struct {
 type CiRequest struct {
 	CiProjectDetails            []CiProjectDetails           `json:"ciProjectDetails"`
 	DockerImageTag              string                       `json:"dockerImageTag"`
-	DockerRegistryId		  string			 			 `json:"dockerRegistryId"`
+	DockerRegistryId            string                       `json:"dockerRegistryId"`
 	DockerRegistryType          string                       `json:"dockerRegistryType"`
 	DockerRegistryURL           string                       `json:"dockerRegistryURL"`
 	DockerConnection            string                       `json:"dockerConnection"`

--- a/App.go
+++ b/App.go
@@ -77,6 +77,7 @@ type CiArtifactDTO struct {
 type CiRequest struct {
 	CiProjectDetails            []CiProjectDetails           `json:"ciProjectDetails"`
 	DockerImageTag              string                       `json:"dockerImageTag"`
+	DockerRegistryId		  string			 			 `json:"dockerRegistryId"`
 	DockerRegistryType          string                       `json:"dockerRegistryType"`
 	DockerRegistryURL           string                       `json:"dockerRegistryURL"`
 	DockerConnection            string                       `json:"dockerConnection"`
@@ -454,9 +455,7 @@ func runCIStages(ciCdRequest *CiCdTriggerEvent) (artifactUploaded bool, err erro
 		logStage("IMAGE SCAN")
 		log.Println(devtron, " /image-scanner")
 		scanEvent := &ScanEvent{Image: dest, ImageDigest: digest, PipelineId: ciCdRequest.CiRequest.PipelineId, UserId: ciCdRequest.CiRequest.TriggeredBy}
-		scanEvent.AccessKey = ciCdRequest.CiRequest.AccessKey
-		scanEvent.SecretKey = ciCdRequest.CiRequest.SecretKey
-		scanEvent.AwsRegion = ciCdRequest.CiRequest.AwsRegion
+		scanEvent.DockerRegistryId = ciCdRequest.CiRequest.DockerRegistryId
 		err = SendEventToClairUtility(scanEvent)
 		if err != nil {
 			log.Println(err)

--- a/EventUtil.go
+++ b/EventUtil.go
@@ -223,16 +223,16 @@ func SendEventToClairUtility(event *ScanEvent) error {
 }
 
 type ScanEvent struct {
-	Image        string `json:"image"`
-	ImageDigest  string `json:"imageDigest"`
-	AppId        int    `json:"appId"`
-	EnvId        int    `json:"envId"`
-	PipelineId   int    `json:"pipelineId"`
-	CiArtifactId int    `json:"ciArtifactId"`
-	UserId       int    `json:"userId"`
-	AccessKey    string `json:"accessKey"`
-	SecretKey    string `json:"secretKey"`
-	Token        string `json:"token"`
-	AwsRegion    string `json:"awsRegion"`
+	Image            string `json:"image"`
+	ImageDigest      string `json:"imageDigest"`
+	AppId            int    `json:"appId"`
+	EnvId            int    `json:"envId"`
+	PipelineId       int    `json:"pipelineId"`
+	CiArtifactId     int    `json:"ciArtifactId"`
+	UserId           int    `json:"userId"`
+	AccessKey        string `json:"accessKey"`
+	SecretKey        string `json:"secretKey"`
+	Token            string `json:"token"`
+	AwsRegion        string `json:"awsRegion"`
 	DockerRegistryId string `json:"dockerRegistryId"`
 }

--- a/EventUtil.go
+++ b/EventUtil.go
@@ -234,4 +234,5 @@ type ScanEvent struct {
 	SecretKey    string `json:"secretKey"`
 	Token        string `json:"token"`
 	AwsRegion    string `json:"awsRegion"`
+	DockerRegistryId string `json:"dockerRegistryId"`
 }


### PR DESCRIPTION
For image scanning, docker registry passwords and token are currently not being sent to image-scanner. Updated the payload to image-scanner with dockerRegistryId to get the same data in image-scanner from db.