### PR TITLE
feat: Updated support for hiding docker build arguments from logs

### DIFF
--- a/helper/DockerHelper.go
+++ b/helper/DockerHelper.go
@@ -99,7 +99,7 @@ type DockerCredentials struct {
 }
 
 type EnvironmentVariables struct {
-	showDockerBuildCmdInLogs bool `env:"SHOW_DOCKER_BUILD_ARGS" envDefault:"true"`
+	ShowDockerBuildCmdInLogs bool `env:"SHOW_DOCKER_BUILD_ARGS" envDefault:"true"`
 }
 
 func DockerLogin(dockerCredentials *DockerCredentials) error {
@@ -261,7 +261,7 @@ func BuildArtifact(ciRequest *CiRequest) (string, error) {
 	} else {
 		dockerBuild = fmt.Sprintf("%s -f %s --network host -t %s .", dockerBuild, ciRequest.DockerFileLocation, ciRequest.DockerRepository)
 	}
-	if envVars.showDockerBuildCmdInLogs {
+	if envVars.ShowDockerBuildCmdInLogs {
 		log.Println("Starting docker build : ", dockerBuild)
 	} else {
 		log.Println("Docker build started..")


### PR DESCRIPTION
# Description

We print docker build command independent of the data it contains. If the docker build arguments contain some sensitive information then it should not be exposed in logs. Added an environment variable to configure the option to hide docker build log.