### PR TITLE
feat: saved failed step detail, sent Nats message with the step name on failures

### DIFF
--- a/App.go
+++ b/App.go
@@ -187,8 +187,8 @@ func sendFailureNotification(failureMessage string, ciRequest *helper.CiRequest,
 type CiFailReason string
 
 const (
-	PreCi  CiFailReason = "Pre-CI step failed: "
-	PostCi CiFailReason = "Post-CI step failed: "
+	PreCi  CiFailReason = "Pre-CI task failed: "
+	PostCi CiFailReason = "Post-CI task failed: "
 	Build  CiFailReason = "Docker build failed"
 	Push   CiFailReason = "Docker push failed"
 	Scan   CiFailReason = "Image scan failed"

--- a/App.go
+++ b/App.go
@@ -57,8 +57,13 @@ func main() {
 			artifactUploaded, artifactUploadErr = helper.ZipAndUpload(ciRequest.BlobStorageConfigured, ciCdRequest.CiRequest.BlobStorageS3Config, ciCdRequest.CiRequest.CiArtifactFileName, ciCdRequest.CiRequest.CloudProvider, ciCdRequest.CiRequest.AzureBlobConfig, ciCdRequest.CiRequest.GcpBlobConfig)
 		}
 
-		if err != nil || artifactUploadErr != nil {
-			log.Println(util.DEVTRON, err, artifactUploadErr)
+		if err != nil {
+			log.Println(util.DEVTRON, err)
+			os.Exit(2)
+		}
+
+		if artifactUploadErr != nil {
+			log.Println(util.DEVTRON, artifactUploadErr)
 			os.Exit(1)
 		}
 
@@ -232,6 +237,7 @@ func runCIStages(ciCdRequest *helper.CiCdTriggerEvent) (artifactUploaded bool, e
 	}
 
 	var preeCiStageOutVariable map[int]map[string]*helper.VariableObject
+	var step *helper.StepObject
 	var preCiDuration float64
 	start = time.Now()
 	metrics.PreCiStartTime = start
@@ -241,10 +247,11 @@ func runCIStages(ciCdRequest *helper.CiCdTriggerEvent) (artifactUploaded bool, e
 			util.LogStage("running PRE-CI steps")
 		}
 		// run pre artifact processing
-		preeCiStageOutVariable, err = RunCiSteps(STEP_TYPE_PRE, ciCdRequest.CiRequest.PreCiSteps, refStageMap, scriptEnvs, nil)
+		preeCiStageOutVariable, step, err = RunCiSteps(STEP_TYPE_PRE, ciCdRequest.CiRequest.PreCiSteps, refStageMap, scriptEnvs, nil)
 		preCiDuration = time.Since(start).Seconds()
 		if err != nil {
 			log.Println(err)
+			helper.SendEvents(ciCdRequest.CiRequest, "", "", helper.CIMetrics{}, artifactUploaded, step.Name)
 			return artifactUploaded, err
 		}
 	}
@@ -280,9 +287,10 @@ func runCIStages(ciCdRequest *helper.CiCdTriggerEvent) (artifactUploaded bool, e
 		// sending build success as true always as post-ci triggers only if ci gets success
 		scriptEnvs[util.ENV_VARIABLE_BUILD_SUCCESS] = "true"
 		// run post artifact processing
-		_, err = RunCiSteps(STEP_TYPE_POST, ciCdRequest.CiRequest.PostCiSteps, refStageMap, scriptEnvs, preeCiStageOutVariable)
+		_, step, err = RunCiSteps(STEP_TYPE_POST, ciCdRequest.CiRequest.PostCiSteps, refStageMap, scriptEnvs, preeCiStageOutVariable)
 		postCiDuration = time.Since(start).Seconds()
 		if err != nil {
+			helper.SendEvents(ciCdRequest.CiRequest, "", "", helper.CIMetrics{}, artifactUploaded, step.Name)
 			return artifactUploaded, err
 		}
 	}
@@ -339,7 +347,7 @@ func runCIStages(ciCdRequest *helper.CiCdTriggerEvent) (artifactUploaded bool, e
 	log.Println(util.DEVTRON, " event")
 	metrics.TotalDuration = time.Since(metrics.TotalStartTime).Seconds()
 
-	err = helper.SendEvents(ciCdRequest.CiRequest, digest, dest, metrics, artifactUploaded)
+	err = helper.SendEvents(ciCdRequest.CiRequest, digest, dest, metrics, artifactUploaded, "")
 	if err != nil {
 		log.Println(err)
 		return artifactUploaded, err

--- a/helper/CiStageError.go
+++ b/helper/CiStageError.go
@@ -1,0 +1,13 @@
+package helper
+
+type CiStageError struct {
+	Err error
+}
+
+func (err CiStageError) Error() string {
+	return err.Err.Error()
+}
+
+func (err *CiStageError) Unwrap() error {
+	return err.Err
+}

--- a/helper/EventHelper.go
+++ b/helper/EventHelper.go
@@ -202,7 +202,7 @@ type CiCompleteEvent struct {
 	Metrics            CIMetrics          `json:"metrics"`
 	AppName            string             `json:"appName"`
 	IsArtifactUploaded bool               `json:"isArtifactUploaded"`
-	FailedStepName     string             `json:"failedStepName"`
+	FailureReason      string             `json:"failureReason"`
 }
 
 type CdStageCompleteEvent struct {
@@ -273,7 +273,7 @@ func SendCDEvent(cdRequest *CdRequest) error {
 	return nil
 }
 
-func SendEvents(ciRequest *CiRequest, digest string, image string, metrics CIMetrics, artifactUploaded bool, failedStepName string) error {
+func SendEvents(ciRequest *CiRequest, digest string, image string, metrics CIMetrics, artifactUploaded bool, failureReason string) error {
 
 	event := CiCompleteEvent{
 		CiProjectDetails:   ciRequest.CiProjectDetails,
@@ -288,7 +288,7 @@ func SendEvents(ciRequest *CiRequest, digest string, image string, metrics CIMet
 		Metrics:            metrics,
 		AppName:            ciRequest.AppName,
 		IsArtifactUploaded: artifactUploaded,
-		FailedStepName:     failedStepName,
+		FailureReason:      failureReason,
 	}
 
 	err := SendCiCompleteEvent(event)

--- a/helper/EventHelper.go
+++ b/helper/EventHelper.go
@@ -202,6 +202,7 @@ type CiCompleteEvent struct {
 	Metrics            CIMetrics          `json:"metrics"`
 	AppName            string             `json:"appName"`
 	IsArtifactUploaded bool               `json:"isArtifactUploaded"`
+	FailedStepName     string             `json:"failedStepName"`
 }
 
 type CdStageCompleteEvent struct {
@@ -272,7 +273,7 @@ func SendCDEvent(cdRequest *CdRequest) error {
 	return nil
 }
 
-func SendEvents(ciRequest *CiRequest, digest string, image string, metrics CIMetrics, artifactUploaded bool) error {
+func SendEvents(ciRequest *CiRequest, digest string, image string, metrics CIMetrics, artifactUploaded bool, failedStepName string) error {
 
 	event := CiCompleteEvent{
 		CiProjectDetails:   ciRequest.CiProjectDetails,
@@ -287,7 +288,9 @@ func SendEvents(ciRequest *CiRequest, digest string, image string, metrics CIMet
 		Metrics:            metrics,
 		AppName:            ciRequest.AppName,
 		IsArtifactUploaded: artifactUploaded,
+		FailedStepName:     failedStepName,
 	}
+
 	err := SendCiCompleteEvent(event)
 	if err != nil {
 		log.Println(util.DEVTRON, "err", err)


### PR DESCRIPTION
<!--
Type of change: Title of the PR should clearly mention which type of PR is this, you can select any of the below mentioned types:

- docs - The PR contains Documentation ONLY changes. 
- feat - The PR contains new feature/enhancements.
- fix - The PR contains a bug fix.
- chore - Development changes related to the build system (involving scripts, configurations or tools) and package dependencies.
- test - Development changes related to tests.
- perf - Changes related to performance improvements.

Example Title: 
docs: Webhook CI documentation changes
-->

# Description
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->

Fixes #
_Added handling for capturing the state name on step failure, and sent NATS message with the details emitting a new error code(2) for step execution failures so that it can be handled appropriately in orchestrator _

## How Has This Been Tested?
Manually tested on a local cluster with changes on orchestrator
<!--test-cases
- [ ] Test case A
- [ ] Test case B
-->

## Checklist:

* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR requires documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have performed a self-review of my own code.
* [x] I have commented my code, particularly in hard-to-understand areas.
* [ ] I have tested it for all user roles.
* [ ] I have added all the required unit/api test cases.

## Does this PR introduce a user-facing change?
<!--
If NO, leave the release-note block blank.
If YES, a release note is required:
Enter your extended release note in the block below. If the PR requires additional manual action from users switching to the new version, include the string "action-required".

-->
```release-note

```

