### PR TITLE
fix: remove double quotes from env input variables

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ COPY . .
 RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o /go/bin/cirunner
 
 
-FROM docker:20.10.17-dind
+FROM docker:20.10.24-dind
 # All these steps will be cached
 #RUN apk add --no-cache ca-certificates
 RUN apk update && apk add --no-cache --virtual .build-deps && apk add bash && apk add make && apk add curl && apk add openssh && apk add git && apk add zip && apk add jq

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ COPY . .
 RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o /go/bin/cirunner
 
 
-FROM docker:20.10.24-dind
+FROM docker:20.10.17-dind
 # All these steps will be cached
 #RUN apk add --no-cache ca-certificates
 RUN apk update && apk add --no-cache --virtual .build-deps && apk add bash && apk add make && apk add curl && apk add openssh && apk add git && apk add zip && apk add jq

--- a/scriptExecutor.go
+++ b/scriptExecutor.go
@@ -243,7 +243,7 @@ set -e
 
 func buildDockerRunCommand(executionConf *executionConf) (string, error) {
 	cmdTemplate := `docker run --network host \
---env-file {{.EnvInputFileName}} \
+--env-file <(sed 's/"//g' {{.EnvInputFileName}})
 -v {{.EntryScriptFileName}}:/devtron_script/_entry.sh \
 -v {{.EnvOutFileName}}:/devtron_script/_out.env \
 {{- if .SourceCodeMount }}

--- a/scriptExecutor.go
+++ b/scriptExecutor.go
@@ -15,8 +15,6 @@ import (
 	"strings"
 )
 
-const doubleQuoteSpecialChars = "\\\n\r\"!$`"
-
 func RunScriptsV1(outputPath string, bashScript string, script string, envVars map[string]string) error {
 	log.Println("running script commands")
 	scriptTemplate := `#!/bin/sh
@@ -355,23 +353,9 @@ func Marshal(envMap map[string]string) (string, error) {
 		if d, err := strconv.Atoi(v); err == nil {
 			lines = append(lines, fmt.Sprintf(`%s=%d`, k, d))
 		} else {
-			lines = append(lines, fmt.Sprintf(`%s=%s`, k, doubleQuoteEscape(v)))
+			lines = append(lines, fmt.Sprintf(`%s=%s`, k, v))
 		}
 	}
 	sort.Strings(lines)
 	return strings.Join(lines, "\n"), nil
-}
-
-func doubleQuoteEscape(line string) string {
-	for _, c := range doubleQuoteSpecialChars {
-		toReplace := "\\" + string(c)
-		if c == '\n' {
-			toReplace = `\n`
-		}
-		if c == '\r' {
-			toReplace = `\r`
-		}
-		line = strings.Replace(line, string(c), toReplace, -1)
-	}
-	return line
 }

--- a/scriptExecutor.go
+++ b/scriptExecutor.go
@@ -197,7 +197,7 @@ func RunScriptsInDocker(executionConf *executionConf) (map[string]string, error)
 		log.Println(util.DEVTRON, err)
 		return nil, err
 	}
-	fmt.Println(dockerRunCommand)
+	log.Println("docker run command is ", dockerRunCommand)
 	//dockerRunCommand = "echo hello------;sleep 10; echo done------"
 	err = os.WriteFile(executionConf.RunCommandFileName, []byte(dockerRunCommand), 0644)
 	if err != nil {
@@ -227,7 +227,7 @@ set -e
 > {{.envOutFileName}}
 {{$envOutFileName := .envOutFileName}}
 {{- range .outputVars -}} 
-  printf "\n{{.}}=%s" ${{.}} >> {{$envOutFileName}}
+  printf "\n{{.}}=%s" "${{.}}" >> {{$envOutFileName}}
 {{end -}}`
 
 	templateData := make(map[string]interface{})

--- a/scriptExecutor.go
+++ b/scriptExecutor.go
@@ -228,8 +228,10 @@ func writeEnvFile(fileName string, envVars map[string]string) error {
 	defer file.Close()
 
 	for key, value := range envVars {
-		// Remove double quotes from the value
-		value = strings.ReplaceAll(value, "\"", "")
+		// Remove double quotes from the first and last characters of the value
+		if len(value) >= 2 && value[0] == '"' && value[len(value)-1] == '"' {
+			value = value[1 : len(value)-1]
+		}
 
 		// Write key-value pair to file
 		_, err := file.WriteString(fmt.Sprintf("%s=%s\n", key, value))

--- a/scriptExecutor.go
+++ b/scriptExecutor.go
@@ -198,10 +198,8 @@ func RunScriptsInDocker(executionConf *executionConf) (map[string]string, error)
 	// Write each key-value pair to the file
 	for key, value := range executionConf.EnvInputVars {
 		// Format the key-value pair
-		line := fmt.Sprintf("%s=%s\n", key, value)
-
-		// Write the line to the file
-		_, err = writer.WriteString(line)
+		line := fmt.Sprintf("%s : %v\n", key, value)
+		_, err = file.WriteString(line)
 		if err != nil {
 			panic(err)
 		}

--- a/scriptExecutor.go
+++ b/scriptExecutor.go
@@ -175,6 +175,17 @@ func RunScriptsInDocker(executionConf *executionConf) (map[string]string, error)
 		log.Println(util.DEVTRON, err)
 		return nil, err
 	}
+
+	log.Println("Key and values are ", executionConf.EnvInputVars)
+	err = godotenv.Load(envInputFileName)
+	if err != nil {
+		log.Fatalf("Error loading environment file: %s", err.Error())
+	}
+
+	// Access the environment variables
+	value := os.Getenv("VARIABLE_NAME")
+	log.Println("value obtained is ", value)
+	log.Println("Env Input file is ", envInputFileName)
 	entryScript, err := buildDockerEntryScript(executionConf.command, executionConf.args, executionConf.OutputVars)
 	if err != nil {
 		log.Println(util.DEVTRON, err)
@@ -243,7 +254,7 @@ set -e
 
 func buildDockerRunCommand(executionConf *executionConf) (string, error) {
 	cmdTemplate := `docker run --network host \
---env-file <(sed 's/"//g' {{.EnvInputFileName}}) \
+--env-file {{.EnvInputFileName}} \
 -v {{.EntryScriptFileName}}:/devtron_script/_entry.sh \
 -v {{.EnvOutFileName}}:/devtron_script/_out.env \
 {{- if .SourceCodeMount }}

--- a/scriptExecutor.go
+++ b/scriptExecutor.go
@@ -172,7 +172,8 @@ func RunScriptsInDocker(executionConf *executionConf) (map[string]string, error)
 	executionConf.EntryScriptFileName = entryScriptFileName
 	executionConf.EnvOutFileName = envOutFileName
 
-	err := Write(executionConf.EnvInputVars, envInputFileName)
+	//Write env input vars to env file
+	err := writeToEnvFile(executionConf.EnvInputVars, envInputFileName)
 	if err != nil {
 		log.Println(util.DEVTRON, err)
 		return nil, err
@@ -274,8 +275,9 @@ func buildDockerRunCommand(executionConf *executionConf) (string, error) {
 
 }
 
-func Write(envMap map[string]string, filename string) error {
-	content, err := Marshal(envMap)
+// Writes input vars to env file
+func writeToEnvFile(envMap map[string]string, filename string) error {
+	content, err := marshal(envMap)
 	if err != nil {
 		return err
 	}
@@ -292,7 +294,8 @@ func Write(envMap map[string]string, filename string) error {
 	return err
 }
 
-func Marshal(envMap map[string]string) (string, error) {
+// Filters values of env variables on the basis of type and inserts to slice of strings
+func marshal(envMap map[string]string) (string, error) {
 	lines := make([]string, 0, len(envMap))
 	for k, v := range envMap {
 		if d, err := strconv.Atoi(v); err == nil {

--- a/scriptExecutor.go
+++ b/scriptExecutor.go
@@ -170,6 +170,13 @@ func RunScriptsInDocker(executionConf *executionConf) (map[string]string, error)
 	executionConf.EntryScriptFileName = entryScriptFileName
 	executionConf.EnvOutFileName = envOutFileName
 
+	// Remove double quotes at this point and then observe the behaviour, might be a possibility that double quotes are inserted before this point
+
+	for key, value := range executionConf.EnvInputVars {
+		value = strings.Trim(value, "\"")
+		executionConf.EnvInputVars[key] = value
+	}
+
 	err := godotenv.Write(executionConf.EnvInputVars, envInputFileName)
 	if err != nil {
 		log.Println(util.DEVTRON, err)

--- a/scriptExecutor.go
+++ b/scriptExecutor.go
@@ -11,6 +11,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"unicode"
 )
 
 const doubleQuoteSpecialChars = "\\\n\r\"!$`"
@@ -198,7 +199,10 @@ func RunScriptsInDocker(executionConf *executionConf) (map[string]string, error)
 	// Write each key-value pair to the file
 	for key, value := range executionConf.EnvInputVars {
 		// Format the key-value pair
-		line := fmt.Sprintf("%s : %v\n", key, value)
+		//if hasSpecialCharacters(value) {
+		//	line := fmt.Sprintf("%s : %q\n", key, value)
+		//}
+		line := fmt.Sprintf("%s : %q\n", key, value)
 		_, err = file.WriteString(line)
 		if err != nil {
 			panic(err)
@@ -273,6 +277,15 @@ func RunScriptsInDocker(executionConf *executionConf) (map[string]string, error)
 		return nil, err
 	}
 	return envMap, nil
+}
+
+func hasSpecialCharacters(s string) bool {
+	for _, char := range s {
+		if !unicode.IsLetter(char) && !unicode.IsDigit(char) {
+			return true
+		}
+	}
+	return false
 }
 
 func buildDockerEntryScript(command string, args []string, outputVars []string) (string, error) {

--- a/scriptExecutor.go
+++ b/scriptExecutor.go
@@ -10,8 +10,12 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"sort"
+	"strconv"
 	"strings"
 )
+
+const doubleQuoteSpecialChars = "\\\n\r\"!$`"
 
 func RunScriptsV1(outputPath string, bashScript string, script string, envVars map[string]string) error {
 	log.Println("running script commands")
@@ -178,7 +182,7 @@ func RunScriptsInDocker(executionConf *executionConf) (map[string]string, error)
 		executionConf.EnvInputVars[key] = value
 	}
 
-	err := godotenv.Write(executionConf.EnvInputVars, envInputFileName)
+	err := Write(executionConf.EnvInputVars, envInputFileName)
 	if err != nil {
 		log.Println(util.DEVTRON, err)
 		return nil, err
@@ -248,6 +252,52 @@ func RunScriptsInDocker(executionConf *executionConf) (map[string]string, error)
 	}
 	return envMap, nil
 }
+
+func Write(envMap map[string]string, filename string) error {
+	content, err := Marshal(envMap)
+	if err != nil {
+		return err
+	}
+	file, err := os.Create(filename)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+	_, err = file.WriteString(content + "\n")
+	if err != nil {
+		return err
+	}
+	file.Sync()
+	return err
+}
+
+func Marshal(envMap map[string]string) (string, error) {
+	lines := make([]string, 0, len(envMap))
+	for k, v := range envMap {
+		if d, err := strconv.Atoi(v); err == nil {
+			lines = append(lines, fmt.Sprintf(`%s=%d`, k, d))
+		} else {
+			lines = append(lines, fmt.Sprintf(`%s=%s`, k, doubleQuoteEscape(v)))
+		}
+	}
+	sort.Strings(lines)
+	return strings.Join(lines, "\n"), nil
+}
+
+func doubleQuoteEscape(line string) string {
+	for _, c := range doubleQuoteSpecialChars {
+		toReplace := "\\" + string(c)
+		if c == '\n' {
+			toReplace = `\n`
+		}
+		if c == '\r' {
+			toReplace = `\r`
+		}
+		line = strings.Replace(line, string(c), toReplace, -1)
+	}
+	return line
+}
+
 func buildDockerEntryScript(command string, args []string, outputVars []string) (string, error) {
 	log.Println("output variables are ", outputVars)
 	entryTemplate := `#!/bin/sh

--- a/scriptExecutor.go
+++ b/scriptExecutor.go
@@ -243,7 +243,7 @@ set -e
 
 func buildDockerRunCommand(executionConf *executionConf) (string, error) {
 	cmdTemplate := `docker run --network host \
---env-file <(sed 's/"//g' {{.EnvInputFileName}})
+--env-file <(sed 's/"//g' {{.EnvInputFileName}}) \
 -v {{.EntryScriptFileName}}:/devtron_script/_entry.sh \
 -v {{.EnvOutFileName}}:/devtron_script/_out.env \
 {{- if .SourceCodeMount }}

--- a/scriptExecutor.go
+++ b/scriptExecutor.go
@@ -355,7 +355,7 @@ func Marshal(envMap map[string]string) (string, error) {
 		if d, err := strconv.Atoi(v); err == nil {
 			lines = append(lines, fmt.Sprintf(`%s=%d`, k, d))
 		} else {
-			lines = append(lines, fmt.Sprintf(`%s=%s`, k, v))
+			lines = append(lines, fmt.Sprintf(`%s=%s`, k, doubleQuoteEscape(v)))
 		}
 	}
 	sort.Strings(lines)

--- a/scriptExecutor.go
+++ b/scriptExecutor.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bufio"
 	"fmt"
 	"github.com/devtron-labs/ci-runner/helper"
 	"github.com/devtron-labs/ci-runner/util"
@@ -181,6 +182,27 @@ func RunScriptsInDocker(executionConf *executionConf) (map[string]string, error)
 	if err != nil {
 		log.Println(util.DEVTRON, err)
 		return nil, err
+	}
+
+	file, err := os.Open(envInputFileName)
+	if err != nil {
+		log.Println("Error opening file:", err)
+		return nil, err
+	}
+	defer file.Close()
+
+	// Create a new scanner to read the file line by line
+	scanner := bufio.NewScanner(file)
+
+	// Read the file line by line
+	for scanner.Scan() {
+		line := scanner.Text()
+		log.Println("Line received is ", line)
+	}
+
+	// Check if there was an error while scanning
+	if err = scanner.Err(); err != nil {
+		log.Println("Error reading file:", err)
 	}
 
 	entryScript, err := buildDockerEntryScript(executionConf.command, executionConf.args, executionConf.OutputVars)

--- a/scriptExecutor.go
+++ b/scriptExecutor.go
@@ -177,8 +177,7 @@ func RunScriptsInDocker(executionConf *executionConf) (map[string]string, error)
 	// Remove double quotes at this point and then observe the behaviour, might be a possibility that double quotes are inserted before this point
 
 	for key, value := range executionConf.EnvInputVars {
-		value = strings.Trim(value, "\"")
-		executionConf.EnvInputVars[key] = value
+		log.Println("The key is ", key, " and the value is ", value)
 	}
 
 	//err := Write(executionConf.EnvInputVars, envInputFileName)
@@ -199,10 +198,12 @@ func RunScriptsInDocker(executionConf *executionConf) (map[string]string, error)
 	// Write each key-value pair to the file
 	for key, value := range executionConf.EnvInputVars {
 		// Format the key-value pair
-		//if hasSpecialCharacters(value) {
-		//	line := fmt.Sprintf("%s : %q\n", key, value)
-		//}
-		line := fmt.Sprintf("%s : %q\n", key, value)
+		var line string
+		if hasSpecialCharacters(value) {
+			line = fmt.Sprintf("%s : %q\n", key, value)
+		} else {
+			line = fmt.Sprintf("%s : %s\n", key, value)
+		}
 		_, err = file.WriteString(line)
 		if err != nil {
 			panic(err)

--- a/scriptExecutor.go
+++ b/scriptExecutor.go
@@ -199,7 +199,7 @@ func RunScriptsInDocker(executionConf *executionConf) (map[string]string, error)
 	for key, value := range executionConf.EnvInputVars {
 		// Format the key-value pair
 		log.Println("The key is ", key, " and the value is ", value)
-		line := fmt.Sprintf("%s : %s\n", key, value)
+		line := fmt.Sprintf(`%s : %s\n`, key, value)
 		_, err = file.WriteString(line)
 		if err != nil {
 			panic(err)

--- a/scriptExecutor.go
+++ b/scriptExecutor.go
@@ -277,7 +277,7 @@ func buildDockerRunCommand(executionConf *executionConf) (string, error) {
 
 // Writes input vars to env file
 func writeToEnvFile(envMap map[string]string, filename string) error {
-	content := marshal(envMap)
+	content := formatEnvironmentVariables(envMap)
 	file, err := os.Create(filename)
 	if err != nil {
 		log.Println(util.DEVTRON, "error while creating env file ", err)
@@ -294,7 +294,7 @@ func writeToEnvFile(envMap map[string]string, filename string) error {
 }
 
 // Filters values of env variables on the basis of type and inserts to slice of strings
-func marshal(envMap map[string]string) string {
+func formatEnvironmentVariables(envMap map[string]string) string {
 	lines := make([]string, 0, len(envMap))
 	for k, v := range envMap {
 		d, err := strconv.Atoi(v)

--- a/scriptExecutor.go
+++ b/scriptExecutor.go
@@ -220,6 +220,7 @@ func RunScriptsInDocker(executionConf *executionConf) (map[string]string, error)
 	return envMap, nil
 }
 func buildDockerEntryScript(command string, args []string, outputVars []string) (string, error) {
+	log.Println("output variables are ", outputVars)
 	entryTemplate := `#!/bin/sh
 set -e
 {{.command}} {{.args}}

--- a/scriptExecutor.go
+++ b/scriptExecutor.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"bufio"
 	"fmt"
 	"github.com/devtron-labs/ci-runner/helper"
 	"github.com/devtron-labs/ci-runner/util"
@@ -173,62 +172,10 @@ func RunScriptsInDocker(executionConf *executionConf) (map[string]string, error)
 	executionConf.EntryScriptFileName = entryScriptFileName
 	executionConf.EnvOutFileName = envOutFileName
 
-	// Remove double quotes at this point and then observe the behaviour, might be a possibility that double quotes are inserted before this point
-
-	for key, value := range executionConf.EnvInputVars {
-		log.Println("The key is ", key, " and the value is ", value)
-	}
-
 	err := Write(executionConf.EnvInputVars, envInputFileName)
 	if err != nil {
 		log.Println(util.DEVTRON, err)
 		return nil, err
-	}
-
-	//file, err := os.Create(envInputFileName)
-	//if err != nil {
-	//	panic(err)
-	//}
-	//defer file.Close()
-	//
-	//// Create a buffered writer
-	//writer := bufio.NewWriter(file)
-	//
-	//// Write each key-value pair to the file
-	//for key, value := range executionConf.EnvInputVars {
-	//	// Format the key-value pair
-	//	log.Println("The key is ", key, " and the value is ", value)
-	//	line := fmt.Sprintf(`%s : %s\n`, key, value)
-	//	_, err = file.WriteString(line)
-	//	if err != nil {
-	//		panic(err)
-	//	}
-	//}
-	//
-	//err = writer.Flush()
-	//if err != nil {
-	//	panic(err)
-	//}
-
-	file, err := os.Open(envInputFileName)
-	if err != nil {
-		log.Println("Error opening file:", err)
-		return nil, err
-	}
-	defer file.Close()
-
-	//Create a new scanner to read the file line by line
-	scanner := bufio.NewScanner(file)
-
-	//Read the file line by line
-	for scanner.Scan() {
-		line := scanner.Text()
-		log.Println("Line received is ", line)
-	}
-
-	//Check if there was an error while scanning
-	if err = scanner.Err(); err != nil {
-		log.Println("Error reading file:", err)
 	}
 
 	entryScript, err := buildDockerEntryScript(executionConf.command, executionConf.args, executionConf.OutputVars)
@@ -252,7 +199,6 @@ func RunScriptsInDocker(executionConf *executionConf) (map[string]string, error)
 		log.Println(util.DEVTRON, err)
 		return nil, err
 	}
-	log.Println("docker run command is ", dockerRunCommand)
 	//dockerRunCommand = "echo hello------;sleep 10; echo done------"
 	err = os.WriteFile(executionConf.RunCommandFileName, []byte(dockerRunCommand), 0644)
 	if err != nil {
@@ -276,7 +222,6 @@ func RunScriptsInDocker(executionConf *executionConf) (map[string]string, error)
 }
 
 func buildDockerEntryScript(command string, args []string, outputVars []string) (string, error) {
-	log.Println("output variables are ", outputVars)
 	entryTemplate := `#!/bin/sh
 set -e
 {{.command}} {{.args}}

--- a/scriptExecutor.go
+++ b/scriptExecutor.go
@@ -198,12 +198,8 @@ func RunScriptsInDocker(executionConf *executionConf) (map[string]string, error)
 	// Write each key-value pair to the file
 	for key, value := range executionConf.EnvInputVars {
 		// Format the key-value pair
-		var line string
-		if hasSpecialCharacters(value) {
-			line = fmt.Sprintf("%s : %q\n", key, value)
-		} else {
-			line = fmt.Sprintf("%s : %s\n", key, value)
-		}
+		log.Println("The key is ", key, " and the value is ", value)
+		line := fmt.Sprintf("%s : %s\n", key, value)
 		_, err = file.WriteString(line)
 		if err != nil {
 			panic(err)

--- a/scriptExecutor.go
+++ b/scriptExecutor.go
@@ -10,6 +10,8 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"sort"
+	"strconv"
 	"strings"
 	"unicode"
 )
@@ -180,57 +182,57 @@ func RunScriptsInDocker(executionConf *executionConf) (map[string]string, error)
 		log.Println("The key is ", key, " and the value is ", value)
 	}
 
-	//err := Write(executionConf.EnvInputVars, envInputFileName)
+	err := Write(executionConf.EnvInputVars, envInputFileName)
+	if err != nil {
+		log.Println(util.DEVTRON, err)
+		return nil, err
+	}
+
+	//file, err := os.Create(envInputFileName)
 	//if err != nil {
-	//	log.Println(util.DEVTRON, err)
-	//	return nil, err
+	//	panic(err)
+	//}
+	//defer file.Close()
+	//
+	//// Create a buffered writer
+	//writer := bufio.NewWriter(file)
+	//
+	//// Write each key-value pair to the file
+	//for key, value := range executionConf.EnvInputVars {
+	//	// Format the key-value pair
+	//	log.Println("The key is ", key, " and the value is ", value)
+	//	line := fmt.Sprintf(`%s : %s\n`, key, value)
+	//	_, err = file.WriteString(line)
+	//	if err != nil {
+	//		panic(err)
+	//	}
+	//}
+	//
+	//err = writer.Flush()
+	//if err != nil {
+	//	panic(err)
 	//}
 
-	file, err := os.Create(envInputFileName)
+	file, err := os.Open(envInputFileName)
 	if err != nil {
-		panic(err)
+		log.Println("Error opening file:", err)
+		return nil, err
 	}
 	defer file.Close()
 
-	// Create a buffered writer
-	writer := bufio.NewWriter(file)
+	//Create a new scanner to read the file line by line
+	scanner := bufio.NewScanner(file)
 
-	// Write each key-value pair to the file
-	for key, value := range executionConf.EnvInputVars {
-		// Format the key-value pair
-		log.Println("The key is ", key, " and the value is ", value)
-		line := fmt.Sprintf(`%s : %s\n`, key, value)
-		_, err = file.WriteString(line)
-		if err != nil {
-			panic(err)
-		}
+	//Read the file line by line
+	for scanner.Scan() {
+		line := scanner.Text()
+		log.Println("Line received is ", line)
 	}
 
-	err = writer.Flush()
-	if err != nil {
-		panic(err)
+	//Check if there was an error while scanning
+	if err = scanner.Err(); err != nil {
+		log.Println("Error reading file:", err)
 	}
-
-	//file, err := os.Open(envInputFileName)
-	//if err != nil {
-	//	log.Println("Error opening file:", err)
-	//	return nil, err
-	//}
-	//defer file.Close()
-
-	// Create a new scanner to read the file line by line
-	//scanner := bufio.NewScanner(file)
-
-	// Read the file line by line
-	//for scanner.Scan() {
-	//	line := scanner.Text()
-	//	log.Println("Line received is ", line)
-	//}
-	//
-	// Check if there was an error while scanning
-	//if err = scanner.Err(); err != nil {
-	//	log.Println("Error reading file:", err)
-	//}
 
 	entryScript, err := buildDockerEntryScript(executionConf.command, executionConf.args, executionConf.OutputVars)
 	if err != nil {
@@ -337,4 +339,49 @@ func buildDockerRunCommand(executionConf *executionConf) (string, error) {
 	}
 	return finalScript, nil
 
+}
+
+func Write(envMap map[string]string, filename string) error {
+	content, err := Marshal(envMap)
+	if err != nil {
+		return err
+	}
+	file, err := os.Create(filename)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+	_, err = file.WriteString(content + "\n")
+	if err != nil {
+		return err
+	}
+	file.Sync()
+	return err
+}
+
+func Marshal(envMap map[string]string) (string, error) {
+	lines := make([]string, 0, len(envMap))
+	for k, v := range envMap {
+		if d, err := strconv.Atoi(v); err == nil {
+			lines = append(lines, fmt.Sprintf(`%s=%d`, k, d))
+		} else {
+			lines = append(lines, fmt.Sprintf(`%s=%s`, k, doubleQuoteEscape(v)))
+		}
+	}
+	sort.Strings(lines)
+	return strings.Join(lines, "\n"), nil
+}
+
+func doubleQuoteEscape(line string) string {
+	for _, c := range doubleQuoteSpecialChars {
+		toReplace := "\\" + string(c)
+		if c == '\n' {
+			toReplace = `\n`
+		}
+		if c == '\r' {
+			toReplace = `\r`
+		}
+		line = strings.Replace(line, string(c), toReplace, -1)
+	}
+	return line
 }

--- a/scriptExecutor.go
+++ b/scriptExecutor.go
@@ -13,7 +13,6 @@ import (
 	"sort"
 	"strconv"
 	"strings"
-	"unicode"
 )
 
 const doubleQuoteSpecialChars = "\\\n\r\"!$`"
@@ -278,15 +277,6 @@ func RunScriptsInDocker(executionConf *executionConf) (map[string]string, error)
 	return envMap, nil
 }
 
-func hasSpecialCharacters(s string) bool {
-	for _, char := range s {
-		if !unicode.IsLetter(char) && !unicode.IsDigit(char) {
-			return true
-		}
-	}
-	return false
-}
-
 func buildDockerEntryScript(command string, args []string, outputVars []string) (string, error) {
 	log.Println("output variables are ", outputVars)
 	entryTemplate := `#!/bin/sh
@@ -365,7 +355,7 @@ func Marshal(envMap map[string]string) (string, error) {
 		if d, err := strconv.Atoi(v); err == nil {
 			lines = append(lines, fmt.Sprintf(`%s=%d`, k, d))
 		} else {
-			lines = append(lines, fmt.Sprintf(`%s=%s`, k, doubleQuoteEscape(v)))
+			lines = append(lines, fmt.Sprintf(`%s=%s`, k, v))
 		}
 	}
 	sort.Strings(lines)

--- a/util/CommonConstants.go
+++ b/util/CommonConstants.go
@@ -35,6 +35,8 @@ const ENV_VARIABLE_BUILD_SUCCESS = "BUILD_SUCCESS"
 
 var TmpArtifactLocation = "./job-artifact"
 
+const NewLineChar = "\n"
+
 var (
 	Output_path = filepath.Join(WORKINGDIR, "./process")
 


### PR DESCRIPTION
<!--
Type of change: Title of the PR should clearly mention which type of PR is this, you can select any of the below mentioned types:

- docs - The PR contains Documentation ONLY changes. 
- feat - The PR contains new feature/enhancements.
- fix - The PR contains a bug fix.
- chore - Development changes related to the build system (involving scripts, configurations or tools) and package dependencies.
- test - Development changes related to tests.
- perf - Changes related to performance improvements.

Example Title: 
docs: Webhook CI documentation changes
-->

# Description
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->

Fixes https://github.com/devtron-labs/devtron/issues/1685
Fixes the double quotes issue occuring in input environment variables.
## How Has This Been Tested?
Tested manually for all possible scenarios
<!--test-cases
- [ ] Test case A
- [ ] Test case B
-->

## Checklist:

* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR requires documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have performed a self-review of my own code.
* [x] I have commented my code, particularly in hard-to-understand areas.
* [ ] I have tested it for all user roles.
* [ ] I have added all the required unit/api test cases.

## Does this PR introduce a user-facing change?
<!--
If NO, leave the release-note block blank.
If YES, a release note is required:
Enter your extended release note in the block below. If the PR requires additional manual action from users switching to the new version, include the string "action-required".

-->
```release-note

```

