### PR TITLE
fix: disabled nats event in case of virtual env

### DIFF
--- a/App.go
+++ b/App.go
@@ -490,15 +490,16 @@ func runCDStages(cicdRequest *helper.CiCdTriggerEvent) error {
 	if err != nil {
 		return err
 	}
-
-	log.Println(util.DEVTRON, " event")
-	err = helper.SendCDEvent(cicdRequest.CdRequest)
-	if err != nil {
-		log.Println(err)
-		return err
+	// dry run flag indicates that ci runner image is being run from external helm chart
+	if !cicdRequest.CdRequest.IsDryRun {
+		log.Println(util.DEVTRON, " event")
+		err = helper.SendCDEvent(cicdRequest.CdRequest)
+		if err != nil {
+			log.Println(err)
+			return err
+		}
+		log.Println(util.DEVTRON, " /event")
 	}
-	log.Println(util.DEVTRON, " /event")
-
 	err = helper.StopDocker()
 	if err != nil {
 		log.Println("err", err)

--- a/helper/EventHelper.go
+++ b/helper/EventHelper.go
@@ -177,6 +177,7 @@ type CdRequest struct {
 	DeploymentTriggerTime      time.Time                         `json:"deploymentTriggerTime"`
 	CiRunnerDockerMtuValue     int                               `json:"ciRunnerDockerMtuValue"`
 	DeploymentReleaseCounter   int                               `json:"deploymentReleaseCounter,omitempty"`
+	IsDryRun                   bool                              `json:"isDryRun"`
 }
 
 type CiCdTriggerEvent struct {


### PR DESCRIPTION
disabling nats event if chart is installed manually by user, i.e in case of virtual cluster 