### PR TITLE
fix for env var containing '='

### DIFF
--- a/envUtils.go
+++ b/envUtils.go
@@ -67,7 +67,7 @@ func getSystemEnvVariables() map[string]string {
 	//get all environment variables
 	envVars := os.Environ()
 	for _, envVar := range envVars {
-		a := strings.Split(envVar, "=")
+		a := strings.SplitN(envVar, "=", 2)
 		envs[a[0]] = a[1]
 	}
 	return envs

--- a/envUtils.go
+++ b/envUtils.go
@@ -67,8 +67,10 @@ func getSystemEnvVariables() map[string]string {
 	//get all environment variables
 	envVars := os.Environ()
 	for _, envVar := range envVars {
-		a := strings.SplitN(envVar, "=", 2)
-		envs[a[0]] = a[1]
+		before, after, found := strings.Cut(envVar, "=")
+		if found {
+			envs[before] = after
+		}
 	}
 	return envs
 }


### PR DESCRIPTION
Env variables key-value pair were split by '=' and hence in case of '=' in env var value the code used to break with giving incomplete value. Updated split operation to only split key and value.