### PR TITLE
fix: strings.Quote escaping newline, tab literals 

### DIFF
--- a/helper/DockerHelper.go
+++ b/helper/DockerHelper.go
@@ -406,7 +406,7 @@ func parseDockerFlagParam(param string) string {
 	}
 	unquotedString := strings.Trim(value, "\"")
 
-	return fmt.Sprintf("=%s", strconv.Quote(unquotedString))
+	return fmt.Sprintf("=\"%s\"", unquotedString)
 }
 
 func getDockerfilePath(CiBuildConfig *CiBuildConfigBean, checkoutPath string) string {

--- a/helper/DockerHelper.go
+++ b/helper/DockerHelper.go
@@ -404,9 +404,9 @@ func parseDockerFlagParam(param string) string {
 	if strings.HasPrefix(param, DEVTRON_ENV_VAR_PREFIX) {
 		value = os.Getenv(strings.TrimPrefix(param, DEVTRON_ENV_VAR_PREFIX))
 	}
-	unquotedString := strings.Trim(value, "\"")
+	unquotedString := strings.Trim(value, `"`)
 
-	return fmt.Sprintf("=\"%s\"", unquotedString)
+	return fmt.Sprintf(`="%s"`, unquotedString)
 }
 
 func getDockerfilePath(CiBuildConfig *CiBuildConfigBean, checkoutPath string) string {


### PR DESCRIPTION
strconv.Quote was converting newlines, tab to characters breaking docker build command.

Fixes - https://github.com/devtron-labs/devtron/issues/5282