### PR TITLE
fix: target platform command missing in v1 command builder flow

### DIFF
--- a/helper/DockerHelper.go
+++ b/helper/DockerHelper.go
@@ -537,6 +537,11 @@ func (impl *DockerHelperImpl) getBuildxBuildCommandV1(cacheEnabled bool, useCach
 		dockerBuild = fmt.Sprintf("%s --cache-to=type=local,dest=%s,mode=%s --cache-from=type=local,src=%s", dockerBuild, localCachePath, cacheMode, oldCacheBuildxPath)
 	}
 
+	isTargetPlatformSet := dockerBuildConfig.TargetPlatform != ""
+	if isTargetPlatformSet {
+		dockerBuild = fmt.Sprintf("%s --platform %s", dockerBuild, dockerBuildConfig.TargetPlatform)
+	}
+
 	provenanceFlag := dockerBuildConfig.GetProvenanceFlag()
 	dockerBuild = fmt.Sprintf("%s %s", dockerBuild, provenanceFlag)
 	manifestLocation := util.LOCAL_BUILDX_LOCATION + "/manifest.json"


### PR DESCRIPTION
<!--
Type of change: Title of the PR should clearly mention which type of PR is this, you can select any of the below mentioned types:

- docs - The PR contains Documentation ONLY changes. 
- feat - The PR contains new feature/enhancements.
- fix - The PR contains a bug fix.
- chore - Development changes related to the build system (involving scripts, configurations or tools) and package dependencies.
- test - Development changes related to tests.
- perf - Changes related to performance improvements.

Example Title: 
docs: Webhook CI documentation changes
-->

# Description
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->
<!--
For example:
Fixes https://github.com/devtron-labs/devtron/issues/00001
Fixes devtron-labs/devtron#0001

PS: Please ensure that you've attached a valid issue that is OPEN
-->
images are not build for multi arch even tough multi arch are being selected.
1) not working for emulated buildx.
2) not working with k8s buildx driver if ``ASYNC_BUILDX_CACHE_EXPORT`` 

<!--test-cases
## How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test case A
- [ ] Test case B
-->

## Checklist:

* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR requires documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have performed a self-review of my own code.
* [x] I have commented my code, particularly in hard-to-understand areas.
* [x] I have tested it for all user roles.
* [ ] I have added all the required unit/api test cases.

## Does this PR introduce a user-facing change?
<!--
If NO, leave the release-note block blank.
If YES, a release note is required:
Enter your extended release note in the block below. If the PR requires additional manual action from users switching to the new version, include the string "action-required".

-->
```release-note

```
