### PR TITLE
fix: error handling for gcp blob client

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/aws/aws-sdk-go v1.44.116
 	github.com/aws/aws-sdk-go-v2/service/ecr v1.20.0
 	github.com/caarlos0/env v3.5.0+incompatible
-	github.com/devtron-labs/common-lib v0.16.1-0.20240904133334-7918e7c25b63
+	github.com/devtron-labs/common-lib v0.16.1-0.20240909125937-8f88a0b86754
 	github.com/go-resty/resty/v2 v2.7.0
 	github.com/joho/godotenv v1.4.0
 	github.com/otiai10/copy v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -70,8 +70,8 @@ github.com/containerd/log v0.1.0/go.mod h1:VRRf09a7mHDIRezVKTRCrOq78v577GXq3bSa3
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/devtron-labs/common-lib v0.16.1-0.20240904133334-7918e7c25b63 h1:C5SMozwP2rVIKItqEZs3PtWkBhNnEeHIm9xtnDkK5VA=
-github.com/devtron-labs/common-lib v0.16.1-0.20240904133334-7918e7c25b63/go.mod h1:rAY9Xd6iz+OqNQ3nO3reVHapAVr1N6Osf4Irdc0A08Q=
+github.com/devtron-labs/common-lib v0.16.1-0.20240909125937-8f88a0b86754 h1:EYSSzvNlks7c1F9KwHYwmh1ZXRn029iD5IXLqu7dXU8=
+github.com/devtron-labs/common-lib v0.16.1-0.20240909125937-8f88a0b86754/go.mod h1:rAY9Xd6iz+OqNQ3nO3reVHapAVr1N6Osf4Irdc0A08Q=
 github.com/distribution/reference v0.6.0 h1:0IXCQ5g4/QMHHkarYzh5l+u8T3t73zM5QvfrDyIgxBk=
 github.com/distribution/reference v0.6.0/go.mod h1:BbU0aIcezP1/5jX/8MP0YiH4SdvB5Y4f/wlDRiLyi3E=
 github.com/docker/cli v24.0.6+incompatible h1:fF+XCQCgJjjQNIMjzaSmiKJSCcfcXb3TWTcc7GAneOY=

--- a/vendor/github.com/devtron-labs/common-lib/blob-storage/GCPBlob.go
+++ b/vendor/github.com/devtron-labs/common-lib/blob-storage/GCPBlob.go
@@ -19,6 +19,7 @@ package blob_storage
 import (
 	"cloud.google.com/go/storage"
 	"context"
+	"errors"
 	"fmt"
 	"google.golang.org/api/iterator"
 	"google.golang.org/api/option"
@@ -91,8 +92,10 @@ func (impl *GCPBlob) getLatestVersion(storageClient *storage.Client, request *Bl
 	var latestTimestampInMillis int64 = 0
 	for {
 		objectAttrs, err := objects.Next()
-		if err == iterator.Done {
+		if errors.Is(err, iterator.Done) {
 			break
+		} else if err != nil {
+			return 0, err
 		}
 		objectName := objectAttrs.Name
 		if objectName != fileName {

--- a/vendor/github.com/devtron-labs/common-lib/git-manager/GitCliManager.go
+++ b/vendor/github.com/devtron-labs/common-lib/git-manager/GitCliManager.go
@@ -19,6 +19,7 @@ package git_manager
 import (
 	"fmt"
 	"github.com/devtron-labs/common-lib/git-manager/util"
+	"github.com/sirupsen/logrus"
 	"log"
 	"os"
 	"os/exec"
@@ -286,14 +287,16 @@ func (impl *GitCliManagerImpl) Clone(gitContext GitContext, prj CiProjectDetails
 	}
 	_, msgMsg, cErr = impl.shallowClone(gitContext, checkoutPath, prj.GitRepository, checkoutBranch)
 	if cErr != nil {
-		log.Fatal("could not clone repo ", " err: ", cErr, "msgMsg: ", msgMsg)
+		logrus.Error("could not clone repo ", "msgMsg: ", msgMsg, " err: ", cErr)
+		return "", msgMsg, cErr
 	}
 	projectName := util.GetProjectName(prj.GitRepository)
 	projRootDir := filepath.Join(checkoutPath, projectName)
 
 	_, msgMsg, cErr = impl.moveFilesFromSourceToDestination(projRootDir, checkoutPath)
 	if cErr != nil {
-		log.Fatal("could not move files between files ", "err: ", cErr, "msgMsg: ", msgMsg)
+		logrus.Error("could not move files between files ", "msgMsg: ", msgMsg, "err: ", cErr)
+		return "", msgMsg, cErr
 	}
 	return response, msgMsg, cErr
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -122,7 +122,7 @@ github.com/caarlos0/env
 # github.com/cespare/xxhash/v2 v2.3.0
 ## explicit; go 1.11
 github.com/cespare/xxhash/v2
-# github.com/devtron-labs/common-lib v0.16.1-0.20240904133334-7918e7c25b63
+# github.com/devtron-labs/common-lib v0.16.1-0.20240909125937-8f88a0b86754
 ## explicit; go 1.21
 github.com/devtron-labs/common-lib/blob-storage
 github.com/devtron-labs/common-lib/constants


### PR DESCRIPTION
This PR fixed: Pipeline getting marked as succeeded even when cache pulling fails for GCP blob client.

Fixes https://github.com/devtron-labs/devops-sprint/issues/876